### PR TITLE
Add Arena and Arena API.

### DIFF
--- a/src/main/java/dual/project/tftsimulator/controller/ArenaController.java
+++ b/src/main/java/dual/project/tftsimulator/controller/ArenaController.java
@@ -1,0 +1,26 @@
+package dual.project.tftsimulator.controller;
+
+import dual.project.tftsimulator.model.Champ;
+import dual.project.tftsimulator.model.Unit;
+import dual.project.tftsimulator.model.Point;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/arena")
+public class ArenaController {
+
+    @PostMapping
+    public ResponseEntity<Void> putUnit(@RequestBody Unit unit) {
+        //Logic
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Unit> moveUnit(@RequestBody Point position) {
+        //Logic
+        Unit dummy = new Unit(new Champ("dummy"), position);
+        return new ResponseEntity<>(dummy, HttpStatus.OK);
+    }
+}

--- a/src/main/java/dual/project/tftsimulator/model/Champ.java
+++ b/src/main/java/dual/project/tftsimulator/model/Champ.java
@@ -1,0 +1,17 @@
+package dual.project.tftsimulator.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class Champ {
+    private String name;
+
+    public Champ(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/dual/project/tftsimulator/model/Point.java
+++ b/src/main/java/dual/project/tftsimulator/model/Point.java
@@ -1,0 +1,18 @@
+package dual.project.tftsimulator.model;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Objects;
+
+@Data
+public class Point {
+    private int x;
+    private int y;
+
+    public Point(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+}

--- a/src/main/java/dual/project/tftsimulator/model/Unit.java
+++ b/src/main/java/dual/project/tftsimulator/model/Unit.java
@@ -1,0 +1,14 @@
+package dual.project.tftsimulator.model;
+
+import lombok.Data;
+
+@Data
+public class Unit {
+    private Champ unit;
+    private Point point;
+
+    public Unit(Champ champ, Point position) {
+        this.unit = champ;
+        this.point = position;
+    }
+}

--- a/src/main/java/dual/project/tftsimulator/repo/ArenaMemoryRepo.java
+++ b/src/main/java/dual/project/tftsimulator/repo/ArenaMemoryRepo.java
@@ -1,0 +1,36 @@
+package dual.project.tftsimulator.repo;
+
+import dual.project.tftsimulator.model.Point;
+import dual.project.tftsimulator.model.Unit;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Repository
+public class ArenaMemoryRepo implements ArenaRepo{
+
+    private static final Map<Point, Unit> board = new HashMap<>();
+
+    @Override
+    public Unit save(Unit unit) {
+        return board.putIfAbsent(unit.getPoint(), unit);
+    }
+
+    @Override
+    public Optional<Unit> findById(Long id) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Unit> findByName(String name) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Unit> findAll() {
+        return null;
+    }
+}

--- a/src/main/java/dual/project/tftsimulator/repo/ArenaRepo.java
+++ b/src/main/java/dual/project/tftsimulator/repo/ArenaRepo.java
@@ -1,0 +1,13 @@
+package dual.project.tftsimulator.repo;
+
+import dual.project.tftsimulator.model.Unit;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ArenaRepo {
+    Unit save(Unit unit);
+    Optional<Unit> findById(Long id);
+    Optional<Unit> findByName(String name);
+    List<Unit> findAll();
+}

--- a/src/main/java/dual/project/tftsimulator/service/ArenaService.java
+++ b/src/main/java/dual/project/tftsimulator/service/ArenaService.java
@@ -1,0 +1,48 @@
+package dual.project.tftsimulator.service;
+
+import dual.project.tftsimulator.model.Unit;
+import dual.project.tftsimulator.model.Point;
+import dual.project.tftsimulator.repo.ArenaRepo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class ArenaService {
+
+    private ArenaRepo arenaRepo;
+
+    @Autowired
+    public ArenaService(ArenaRepo arenaRepo) {
+        this.arenaRepo = arenaRepo;
+    }
+
+    public void putUnit(Unit unit) {
+    }
+
+    public Unit takeUnit(Point pos) {
+        return null;
+    }
+
+    public Unit moveUnit(Unit unit, Point posToMove) {
+        return null;
+    }
+
+    public Unit getUnit(Point pos) {
+        return null;
+    }
+
+    public List<Unit> getAllUnits() {
+        return null;
+    }
+
+    private void isValidPosition(Point pos) throws IllegalArgumentException {
+        if (0 <= pos.getX() && pos.getX() < 7 && 0 <= pos.getY() && pos.getY() <= 4) {
+            throw new IllegalArgumentException("존재하지 않는 지표입니다");
+        }
+    }
+}


### PR DESCRIPTION
시뮬레이션 웹앱에 접속해서 결투장 판(Arena)에 챔피언 기물(Unit)을 배치하고 수정하는 백엔드 API 구현.
백엔드에서는 일단 단 하나의 시뮬레이션 판만 가지고 조작하는 것으로 가정. 이후에 여러 시뮬레이션을 만들고 저장하고 불러오는 기능을 만들도록 업데이트할 예정.

Champ 관련 Repositoy와 Service는 따로 만들어서 구현하면 될 듯.